### PR TITLE
[GH#38] mvp gh action to build container images

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -1,0 +1,36 @@
+---
+name: Build and Push Images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        openshift_version: [4.10.12,4.10.14,4.10.18,4.10.22,4.10.3,4.10.9,4.11.0,4.11.1,4.11.13,4.11.18,4.11.3,4.11.7,4.12.0,4.12.1,4.12.13,4.12.5,4.12.9,4.13.0,4.8.12,4.8.5,4.9.0,4.9.10,4.9.12,4.9.15,4.9.18,4.9.5,4.9.8,latest]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./openpipe/build
+          push: true
+          tags: quay.io/${{ secrets.REGISTRY_URL }}:${{ matrix.openshift_version }}
+          build-args: VERSION=${{ matrix.openshift_version }}


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

The idea would be that the github action is the single source of truth for building the redistributable openpipe container images, whereas the gitlab ci file serves as a template for end users to either consume the public images or to build & push them to their own (private) registries.

Followup issue: #40 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
#38 

Link to pipeline run referencing your development branch:
<!--- Add direct link(s) to the exact pipeline (job) relevan to your changes --->


Additional information:
<!--- Optional: Include additional context or expand the description here --->

<!--- After you open your PR, ask for review --->