### PR TITLE
[GH#38] fix ci image builds on gh

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -3,6 +3,15 @@ name: Build and Push Images
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'build/**'
+  pull_request:
+    paths:
+      - 'build/**'
 
 jobs:
   build_and_push:
@@ -12,13 +21,14 @@ jobs:
         openshift_version: [4.10.12,4.10.14,4.10.18,4.10.22,4.10.3,4.10.9,4.11.0,4.11.1,4.11.13,4.11.18,4.11.3,4.11.7,4.12.0,4.12.1,4.12.13,4.12.5,4.12.9,4.13.0,4.8.12,4.8.5,4.9.0,4.9.10,4.9.12,4.9.15,4.9.18,4.9.5,4.9.8,latest]
     steps:
     - uses: actions/checkout@v3
-    - name: Buid image
+    - name: Build image
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
         tags: quay.io/${{ secrets.REGISTRY_URL }}:${{ matrix.openshift_version }}
+        context: build
         containerfiles: |
-          ./build/Containerfile
+          build/Containerfile
         build-args: |
           VERSION=${{ matrix.openshift_version }}
     - name: Push image


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
#38 

Link to pipeline run referencing your development branch:
<!--- Add direct link(s) to the exact pipeline (job) relevan to your changes --->

I've updated the GitHub Actions workflow to build OpenPipe container images using buildah-build with proper context handling. The workflow:

Builds images automatically when:
- Changes are pushed to main/master in build/ directory
- Pull requests modify files in build/ directory
- Manual trigger (workflow_dispatch)

Uses buildah-build with:
- Proper context set to build/ directory ensuring all build files are included
- Matrix strategy to build images for multiple OpenShift versions
- Build arguments to pass OpenShift version to Containerfile
- Pushes images to Quay.io using existing registry configuration (REGISTRY_URL, REGISTRY_USER, REGISTRY_PASSWORD secrets)


Additional information:
<!--- Optional: Include additional context or expand the description here --->

<!--- After you open your PR, ask for review --->